### PR TITLE
Updates I18n to pass hash as keyword argument

### DIFF
--- a/lib/record_select/extensions/localization.rb
+++ b/lib/record_select/extensions/localization.rb
@@ -4,10 +4,10 @@
 class Object
   def rs_(key, options = {})
     unless key.blank?
-      text = I18n.translate "#{key}", {:scope => [:record_select], :default => key.is_a?(String) ? key : key.to_s.titleize}.merge(options)
+      text = I18n.translate "#{key}", **{:scope => [:record_select], :default => key.is_a?(String) ? key : key.to_s.titleize}.merge(options)
       # text = nil if text.include?('translation missing:')
     end
-    text ||= key 
+    text ||= key
     text
   end
 end


### PR DESCRIPTION
Hashes have to be passed as keyword arguments in Rails 2.7 +